### PR TITLE
fix: skip no context

### DIFF
--- a/.github/workflows/deploy-circleci.yml
+++ b/.github/workflows/deploy-circleci.yml
@@ -20,9 +20,13 @@ jobs:
         run: |
           circleci setup --no-prompt --host=https://circleci.com --token=${{ secrets.CIRCLECI_TOKEN }}
 
-      - name: Delete CircleCI Context
+      - name: Check and Delete CircleCI Context
         run: |
-          circleci context delete --org-id ${{ secrets.CIRCLECI_ORG_ID }} checkincontext --force
+          if circleci context list --org-id ${{ secrets.CIRCLECI_ORG_ID }} | grep -q "checkincontext"; then
+            circleci context delete --org-id ${{ secrets.CIRCLECI_ORG_ID }} checkincontext --force
+          else
+            echo "Context does not exist, skipping deletion"
+          fi
 
       - name: Create CircleCI Context
         run: |


### PR DESCRIPTION
For the brand new account, there is no context. So just `grep` the list and skip this step.