### PR TITLE
feat(notifications): unify platform summaries

### DIFF
--- a/deepflood/deepflood.py
+++ b/deepflood/deepflood.py
@@ -1,19 +1,14 @@
-import sys
 import os
 from curl_cffi import requests
 import random
 import time
 from dotenv import load_dotenv
-from telegram.notify import send_tg_notification
+from telegram.notify import send_source_notification
 
 load_dotenv()
 
 # Get COOKIE from environment variable, multiple cookies separated by &
 cookies = os.environ.get('DEEPFLOOD_COOKIE', '').strip()
-
-if not cookies:
-    raise ValueError("Environment variable DEEPFLOOD_COOKIE is not set")
-    sys.exit(1)
 
 # Split multiple cookies by & to form a list
 cookie_list = cookies.split('&')
@@ -26,40 +21,45 @@ headers = {
     'Content-Type': 'application/json',
 }
 
-# Iterate over multiple account cookies for check-in
-for idx, cookie in enumerate(cookie_list):
 
-    print(f"Using the {idx+1} account for check-in...", flush=True)
-    # Generate a random delay
-    random_delay = random.randint(1, 20)
-    print(f"The {idx+1} account will wait for {random_delay} seconds...", flush=True)
-    time.sleep(random_delay)
+def main():
+    results = []
+    failed = False
 
-    # Add cookie to headers
-    headers['Cookie'] = cookie.strip()
-    
-    try:
-        # random=true means get a random bonus
-        url = 'https://www.deepflood.com/api/attendance?random=true'
-        response = requests.post(url, headers=headers, impersonate="chrome136")
-        
-        # Output the status code and response content
-        print(f"The {idx+1} account's Status Code: {response.status_code}", flush=True)
-        print(f"The {idx+1} account's Response Content: {response.text}", flush=True)
-        
-        # Check if the check-in is successful based on the response content
-        if response.status_code == 200:
-            success_message = f"DEEPFLOOD account {idx+1} check-in successful"
-            print(success_message, flush=True)
-            send_tg_notification(success_message)
-        else:
-            fail_message = f"DEEPFLOOD account {idx+1} check-in failed, response content: {response.text}"
-            print(fail_message, flush=True)
-            send_tg_notification(fail_message)
-            sys.exit(1)
-    
-    except Exception as e:
-        error_message = f"DEEPFLOOD account {idx+1} check-in process error: {e}"
-        print(error_message, flush=True)
-        send_tg_notification(error_message)
-        sys.exit(1)
+    if not cookies:
+        results.append("Configuration error: DEEPFLOOD_COOKIE is not set")
+        send_source_notification("DEEPFLOOD", results)
+        return 1
+
+    for idx, cookie in enumerate(cookie_list):
+        account = idx + 1
+        print(f"Using account {account} for check-in...", flush=True)
+        random_delay = random.randint(1, 20)
+        print(f"Account {account} will wait for {random_delay} seconds...", flush=True)
+        time.sleep(random_delay)
+        headers['Cookie'] = cookie.strip()
+
+        try:
+            url = 'https://www.deepflood.com/api/attendance?random=true'
+            response = requests.post(url, headers=headers, impersonate="chrome136")
+            print(f"Account {account} status code: {response.status_code}", flush=True)
+            print(f"Account {account} response: {response.text}", flush=True)
+
+            if response.status_code == 200:
+                result = f"Account {account}: check-in successful"
+            else:
+                result = f"Account {account}: check-in failed — {response.text}"
+                failed = True
+        except Exception as exc:
+            result = f"Account {account}: check-in error — {exc}"
+            failed = True
+
+        print(result, flush=True)
+        results.append(result)
+
+    send_source_notification("DEEPFLOOD", results)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nodeseek/nodeseek.py
+++ b/nodeseek/nodeseek.py
@@ -1,19 +1,14 @@
-import sys
 import os
 from curl_cffi import requests
 import random
 import time
 from dotenv import load_dotenv
-from telegram.notify import send_tg_notification
+from telegram.notify import send_source_notification
 
 load_dotenv()
 
 # Get COOKIE from environment variable, multiple cookies separated by &
 cookies = os.environ.get('NODESEEK_COOKIE', '').strip()
-
-if not cookies:
-    raise ValueError("Environment variable NODESEEK_COOKIE is not set")
-    sys.exit(1)
 
 # Split multiple cookies by & to form a list
 cookie_list = cookies.split('&')
@@ -26,40 +21,45 @@ headers = {
     'Content-Type': 'application/json',
 }
 
-# Iterate over multiple account cookies for check-in
-for idx, cookie in enumerate(cookie_list):
 
-    print(f"Using the {idx+1} account for check-in...", flush=True)
-    # Generate a random delay
-    random_delay = random.randint(1, 20)
-    print(f"The {idx+1} account will wait for {random_delay} seconds...", flush=True)
-    time.sleep(random_delay)
+def main():
+    results = []
+    failed = False
 
-    # Add cookie to headers
-    headers['Cookie'] = cookie.strip()
-    
-    try:
-        # random=true means get a random bonus
-        url = 'https://www.nodeseek.com/api/attendance?random=true'
-        response = requests.post(url, headers=headers, impersonate="chrome136")
-        
-        # Output the status code and response content
-        print(f"The {idx+1} account's Status Code: {response.status_code}", flush=True)
-        print(f"The {idx+1} account's Response Content: {response.text}", flush=True)
-        
-        # Check if the check-in is successful based on the response content
-        if response.status_code == 200:
-            success_message = f"NODESEEK account {idx+1} check-in successful"
-            print(success_message, flush=True)
-            send_tg_notification(success_message)
-        else:
-            fail_message = f"NODESEEK account {idx+1} check-in failed, response content: {response.text}"
-            print(fail_message, flush=True)
-            send_tg_notification(fail_message)
-            sys.exit(1)
-    
-    except Exception as e:
-        error_message = f"NODESEEK account {idx+1} check-in process error: {e}"
-        print(error_message, flush=True)
-        send_tg_notification(error_message)
-        sys.exit(1)
+    if not cookies:
+        results.append("Configuration error: NODESEEK_COOKIE is not set")
+        send_source_notification("NODESEEK", results)
+        return 1
+
+    for idx, cookie in enumerate(cookie_list):
+        account = idx + 1
+        print(f"Using account {account} for check-in...", flush=True)
+        random_delay = random.randint(1, 20)
+        print(f"Account {account} will wait for {random_delay} seconds...", flush=True)
+        time.sleep(random_delay)
+        headers['Cookie'] = cookie.strip()
+
+        try:
+            url = 'https://www.nodeseek.com/api/attendance?random=true'
+            response = requests.post(url, headers=headers, impersonate="chrome136")
+            print(f"Account {account} status code: {response.status_code}", flush=True)
+            print(f"Account {account} response: {response.text}", flush=True)
+
+            if response.status_code == 200:
+                result = f"Account {account}: check-in successful"
+            else:
+                result = f"Account {account}: check-in failed — {response.text}"
+                failed = True
+        except Exception as exc:
+            result = f"Account {account}: check-in error — {exc}"
+            failed = True
+
+        print(result, flush=True)
+        results.append(result)
+
+    send_source_notification("NODESEEK", results)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/onepoint3acres/onepoint3acres.py
+++ b/onepoint3acres/onepoint3acres.py
@@ -8,7 +8,7 @@ import http.cookies
 import time
 from dotenv import load_dotenv
 from .questions import questions
-from telegram.notify import send_tg_notification
+from telegram.notify import send_source_notification
 
 load_dotenv()
 
@@ -24,6 +24,7 @@ class OnePointThreeAcres:
 		self.post_answer_url = "https://api.1point3acres.com/api/daily_questions"
 		self.cookie = cookie
 		self.solver = solver
+		self.messages = []
 		self.session = requests.session()
 		self.session.cookies.update(http.cookies.SimpleCookie(self.cookie))
 		self.header = {
@@ -57,11 +58,11 @@ class OnePointThreeAcres:
 		# }
 		if response.status_code != 200:
 			print(response.text)
+			self.messages.append(f"Check-in failed: {response.text}")
 			return False
 		else:
 			resp_json = json.loads(response.text)
-			# print(resp_json["msg"])
-			send_tg_notification(resp_json["msg"])
+			self.messages.append(resp_json["msg"])
 			return True
 
 	def get_daily_task_answer(self) -> tuple[int, int]:
@@ -89,15 +90,13 @@ class OnePointThreeAcres:
 		question_id = resp_json["question"]["id"]
 		question = resp_json["question"]["qc"]
 		question = question.strip()
-		# print(f"The question of 1point3acres is: {question}")
-		send_tg_notification(f"The question of 1point3acres is: {question}")
+		print(f"The question of 1point3acres is: {question}")
 		answers = {}
 		answers[1] = resp_json["question"]["a1"]
 		answers[2] = resp_json["question"]["a2"]
 		answers[3] = resp_json["question"]["a3"]
 		answers[4] = resp_json["question"]["a4"]
-		# print(f"The options of 1point3acres are: {answers}")
-		send_tg_notification(f"The options of 1point3acres are: {answers}")
+		print(f"The options of 1point3acres are: {answers}")
 		answer = ""
 		answer_id = 0
 		if question in questions.keys():
@@ -110,10 +109,10 @@ class OnePointThreeAcres:
 				print(f"The question: {question}")
 				print(f"answer not found: {answer}")
 				print("欢迎提交 PR 更新问题到 question.py https://github.com/timerring/daily-actions")
-				send_tg_notification(f"answer not found: {answer}, 欢迎提交 PR 更新问题到 https://github.com/timerring/daily-actions")
+				self.messages.append(f"Answer not found: {answer}")
 		else:
 			print("question not found")
-			send_tg_notification("question not found")
+			self.messages.append("Daily question not found")
 			return None, None
 		return question_id, answer_id
 
@@ -191,7 +190,7 @@ class OnePointThreeAcres:
 		# }
 		if "人机验证出错，请重试" in response.text:
 			print("The captcha is wrong")
-			send_tg_notification("The captcha is wrong")
+			self.messages.append("Answer failed: CAPTCHA verification error")
 			self.solver.report(captcha_id, False)
 			return False
 		else:
@@ -199,21 +198,22 @@ class OnePointThreeAcres:
 
 		result = json.loads(response.text)
 		print(result["msg"])
-		send_tg_notification(result["msg"])
+		self.messages.append(result["msg"])
 		if (result["errno"] == 0):
 			return True
 		elif (result["msg"] == "您今天已经答过题了"):
-			send_tg_notification("You have already answered the question today")
 			return True
 		else:
 			print(response.text)
-			send_tg_notification(response.text)
 			return False
 
 
 if __name__ == "__main__":
 	cookie = os.environ.get('ONEPOINT3ACRES_COOKIE', '').strip()
 	TwoCaptcha_apikey = os.environ.get('TWOCAPTCHA_APIKEY', '').strip()
+	messages = []
+	exit_code = 0
+	acres = None
 	
 	try:
 		if not cookie:
@@ -229,7 +229,7 @@ if __name__ == "__main__":
 		# daily checkin
 		daily_checkin_status = acres.daily_checkin()
 		if not daily_checkin_status:
-			send_tg_notification("Fail to check in the 1point3acres")
+			raise ValueError("Fail to check in the 1point3acres")
 		# daily question
 		question_id, answer_id = acres.get_daily_task_answer()
 		if not question_id or not answer_id:
@@ -241,8 +241,14 @@ if __name__ == "__main__":
 		
 	except Exception as err:
 		print(err, flush=True)
-		sys.exit(1)
+		messages.append(f"Error: {err}")
+		exit_code = 1
+	finally:
+		if acres:
+			messages = acres.messages + messages
+		send_source_notification("1POINT3ACRES", messages)
 
+	sys.exit(exit_code)
 
 
 

--- a/telegram/notify.py
+++ b/telegram/notify.py
@@ -3,6 +3,7 @@ import urllib.parse
 import json
 import os
 import sys
+from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -12,6 +13,31 @@ TELEGRAM_TOKEN = os.environ.get('TELEGRAM_TOKEN', '').strip()
 # add the bot to your contact and send a message to it
 # then check the url https://api.telegram.org/bot{TELEGRAM_TOKEN}/getUpdates to get the chat id
 TELEGRAM_CHAT_ID = os.environ.get('TELEGRAM_CHAT_ID', '').strip()
+
+BEIJING_TIMEZONE = timezone(timedelta(hours=8))
+
+
+def format_source_notification(source, messages, now=None):
+    """Format one compact Telegram notification for a platform run."""
+    if isinstance(messages, str):
+        messages = [messages]
+
+    body = "\n".join(
+        str(message).strip()
+        for message in messages
+        if message is not None and str(message).strip()
+    )
+    if not body:
+        body = "No result was reported."
+
+    timestamp = now or datetime.now(BEIJING_TIMEZONE)
+    return f"{timestamp.strftime('%Y/%m/%d %H:%M:%S')}\n{source.upper()}\n{body}"
+
+
+def send_source_notification(source, messages):
+    """Send exactly one formatted notification for a platform run."""
+    send_tg_notification(format_source_notification(source, messages))
+
 
 def send_tg_notification(message):
     """Send Telegram notification
@@ -61,4 +87,4 @@ def send_tg_notification(message):
         conn.close()
 
 if __name__ == "__main__":
-    send_tg_notification("Action test")
+    send_source_notification("TELEGRAM", "Action test")

--- a/tests/test_telegram_notify.py
+++ b/tests/test_telegram_notify.py
@@ -1,0 +1,35 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from telegram.notify import format_source_notification
+
+
+class FormatSourceNotificationTest(unittest.TestCase):
+    def test_formats_single_message(self):
+        now = datetime(2026, 7, 22, 10, 1, 9, tzinfo=timezone(timedelta(hours=8)))
+
+        result = format_source_notification("v2ex", "Check-in successful", now=now)
+
+        self.assertEqual(
+            result,
+            "2026/07/22 10:01:09\nV2EX\nCheck-in successful",
+        )
+
+    def test_combines_account_results(self):
+        now = datetime(2026, 7, 22, 10, 1, 9, tzinfo=timezone(timedelta(hours=8)))
+
+        result = format_source_notification(
+            "deepflood",
+            ["Account 1: successful", "Account 2: failed"],
+            now=now,
+        )
+
+        self.assertEqual(
+            result,
+            "2026/07/22 10:01:09\nDEEPFLOOD\n"
+            "Account 1: successful\nAccount 2: failed",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/v2ex/v2ex.py
+++ b/v2ex/v2ex.py
@@ -1,17 +1,14 @@
 from curl_cffi import requests
 import re
 import os
-from datetime import datetime, timedelta
 import sys
 from dotenv import load_dotenv
-from telegram.notify import send_tg_notification
+from telegram.notify import send_source_notification
 
 load_dotenv()
 
 cookie = os.environ.get('V2EX_COOKIE', '').strip()
-# Initial the message time
-time = datetime.now() + timedelta(hours=8)
-message = time.strftime("%Y/%m/%d %H:%M:%S") + " from V2EX \n"
+message = ""
 headers = {
     "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
     "accept-language": "en-US,en;q=0.9",
@@ -43,7 +40,7 @@ def get_once() -> tuple[str, bool]:
     
     reg1 = r"需要先登录"
     if re.search(reg1, content):
-        message += "The cookie is overdated."
+        message += "The cookie is expired.\n"
         return None, False
     else:
         reg = r"每日登录奖励已领取"
@@ -55,7 +52,7 @@ def get_once() -> tuple[str, bool]:
             once_match = re.search(reg, content)
             if once_match:
                 once = once_match.group(1)
-                message += f"Successfully get once {once}\n"
+                message += "Check-in token acquired.\n"
                 return once, False
             else:
                 message += "Have not signed, but fail to get once\n"
@@ -78,7 +75,6 @@ def check_in(once: str) -> bool:
     reg = r"已成功领取每日登录奖励"
     if re.search(reg, content):
         message += "Check in successfully\n"
-        send_tg_notification(message)
         return True
     else:
         message += "Fail to check in\n"
@@ -107,6 +103,7 @@ def balance() -> tuple[str, str]:
         
 
 if __name__ == "__main__":
+    exit_code = 0
     try:
         if not cookie:
             raise ValueError("Environment variable V2EX_COOKIE is not set")
@@ -115,17 +112,25 @@ if __name__ == "__main__":
         once, signed = get_once()
 
         # check in
-        if once and not signed:
+        if signed:
+            reward_time, current_balance = balance()
+            if reward_time and current_balance:
+                message += f"Latest reward: {reward_time}\nBalance: {current_balance}\n"
+        elif once:
             success = check_in(once)
             if not success:
                 raise ValueError("Fail to check in")
-            time, balance = balance()
-            if not time or not balance:
+            reward_time, current_balance = balance()
+            if not reward_time or not current_balance:
                 raise ValueError("Fail to get balance")
+            message += f"Latest reward: {reward_time}\nBalance: {current_balance}\n"
         else:
-            message += "FAIL.\n"
-            send_tg_notification(message)
             raise ValueError("Fail to check in")
     except Exception as err:
         print(err, flush=True)
-        sys.exit(1)
+        message += f"Error: {err}\n"
+        exit_code = 1
+    finally:
+        send_source_notification("V2EX", message)
+
+    sys.exit(exit_code)


### PR DESCRIPTION
## What changed

- format Telegram messages consistently as timestamp, platform, and result
- send one summary after each V2EX, NodeSeek, DeepFlood, and 1Point3Acres run
- combine multi-account results into one message
- keep 1Point3Acres question and option details in CI logs instead of Telegram
- fix the V2EX already-checked-in path being reported as a failure

## Why

Platform jobs previously sent multiple inconsistent messages, making daily results difficult to scan.

## Validation

- `python -m unittest discover -s tests -v`
- Python compilation checks for the changed platform modules
- `git diff --check`

Natfrp changes are intentionally excluded from this PR.