### PR TITLE
docs: rename SakuraFrp reference labels

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -161,5 +161,5 @@ Welcome to submit platforms you need, no language restrictions.
 - [1point3acres](https://github.com/harryhare/1point3acres)
 - [V2EX](https://github.com/CruiseTian/action-hub)
 - [nodeseek](https://github.com/xinycai/nodeseek_signin)
-- [XavierJiezou/SakuraFRP-Daily-Checkin](https://github.com/XavierJiezou/SakuraFRP-Daily-Checkin)
-- [Solve.md](https://github.com/lyon-le/sakurafrp-auto-sign/blob/main/Solve.md)
+- [SakuraFRP](https://github.com/XavierJiezou/SakuraFRP-Daily-Checkin)
+- [SakuraFRP HTTP protocol](https://github.com/lyon-le/sakurafrp-auto-sign/blob/main/Solve.md)

--- a/README.md
+++ b/README.md
@@ -206,5 +206,5 @@ python -m natfrp.natfrp
 - [1point3acres](https://github.com/harryhare/1point3acres)
 - [V2EX](https://github.com/CruiseTian/action-hub)
 - [nodeseek](https://github.com/xinycai/nodeseek_signin)
-- [XavierJiezou/SakuraFRP-Daily-Checkin](https://github.com/XavierJiezou/SakuraFRP-Daily-Checkin)
-- [Solve.md](https://github.com/lyon-le/sakurafrp-auto-sign/blob/main/Solve.md)
+- [SakuraFRP](https://github.com/XavierJiezou/SakuraFRP-Daily-Checkin)
+- [SakuraFRP HTTP protocol](https://github.com/lyon-le/sakurafrp-auto-sign/blob/main/Solve.md)


### PR DESCRIPTION
## What changed

- Rename the SakuraFrp daily check-in reference label to `SakuraFRP`.
- Rename the protocol reference label to `SakuraFRP HTTP protocol`.
- Keep the Chinese and English README reference lists consistent.

## Why

The shorter labels describe the referenced resources more clearly without exposing repository filenames as display text.

## Validation

- `git diff --check`
- Verified both README files contain the requested labels and unchanged link targets.
