### PR TITLE
docs(readme): simplify SakuraFrp descriptions

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -24,7 +24,7 @@ Automatically complete platform tasks daily. After completion, notifications wil
   - Automatic check-in
   - Automatic quiz completion
 - **SakuraFrp**
-  - Auto login + check-in (pure HTTP GeeTest v3 solve + MiMo AI captcha recognition)
+  - Automatic login and check-in
 
 ## Architecture
 
@@ -105,7 +105,7 @@ https://github.com/timerring/CloudCheckin/blob/0b719258ab4f5f746b067798eb2a4185a
 </details>
 
 <details>
-<summary>Configure SakuraFrp check-in (pure HTTP + AI captcha recognition)</summary>
+<summary>Configure SakuraFrp check-in</summary>
 
 1. Register a [SakuraFrp](https://www.natfrp.com/) account and get your login username and password.
 2. Add your username and password to the repository secrets with the names `SAKURAFRP_USERNAME` and `SAKURAFRP_PASSWORD`.

--- a/README-en.md
+++ b/README-en.md
@@ -141,15 +141,19 @@ python -m sakurafrp.sakurafrp
 
 ## FAQ
 
-1. **Why use CircleCI instead of GitHub Actions directly?**
+1. **What should I do when check-in reports `The cookie is overdated` or the account login state has expired?**
+
+   Obtain a fresh Cookie for the affected platform and update its GitHub Actions repository Secret. Then go to `Actions` and manually run the `Setup CircleCI Context and Secrets` workflow once to synchronize the updated variable to the CircleCI Context.
+
+2. **Why use CircleCI instead of GitHub Actions directly?**
    
    Using GitHub Actions directly may lead to potential repository banning risks. Although this project only triggers requests once a day and doesn't have high concurrent request volumes like upptime and other open-source projects, we still follow the principle of not adding excessive burden to GitHub. CircleCI is also an excellent CI/CD platform. The Free plan's 30,000 credits/mo (up to 6,000 build mins) can fully support all the requirements of this project. Additionally, CircleCI's contexts design between different Projects is quite innovative compared to general CI/CD platforms. More users using and becoming familiar with CircleCI benefits both users and the platform.
 
-2. **Why not use Cloudflare Worker or other Serverless computing functions?**
+3. **Why not use Cloudflare Worker or other Serverless computing functions?**
    
    We have tried Cloudflare Worker. Local `wrangler dev` works, but after deploying to Cloudflare Worker, since Cloudflare edge requests carry obvious cf flags, many platforms have restricted Cloudflare Worker requests.
 
-3. **Why switch to Cloudflare Worker as a Webhook trigger instead of using CircleCI's Scheduled?**
+4. **Why switch to Cloudflare Worker as a Webhook trigger instead of using CircleCI's Scheduled?**
    
    According to [CircleCI's latest terms](https://circleci.com/docs/version-control-system-integration-overview/#pipeline-triggers-and-integrations), Scheduled pipelines will not be available for personal repositories under `GitHub App`, so we need to switch to [Custom Webhook](https://circleci.com/docs/custom-webhooks/) format, using Cloudflare Worker as a scheduled trigger. Of course, you can also use [other ways to call Webhook](https://circleci.com/docs/triggers-overview/#trigger-a-pipeline-from-a-custom-webhook), just need to call the Webhook interface regularly. Here I use Cloudflare Worker as the scheduled trigger.
 

--- a/README.md
+++ b/README.md
@@ -184,15 +184,19 @@ python -m sakurafrp.sakurafrp
 
 ## 常见问题
 
-1. 为什么要采用 CircleCI，不直接用 Github Actions？
+1. 签到提示 `The cookie is overdated` 或账号登录状态失效怎么办？
+
+   重新获取对应平台的 Cookie，并更新仓库中的 GitHub Actions Secret。然后前往 `Actions`，手动运行一次 `Setup CircleCI Context and Secrets` workflow，将更新后的变量同步到 CircleCI Context。
+
+2. 为什么要采用 CircleCI，不直接用 Github Actions？
    
    直接用 Github Actions 容易导致潜在的仓库被封风险，尽管本项目一天只触发一次请求不像 upptime 等开源项目有超高的并发请求量，但是本着本分的原则，还是不要给 Github 添加过多负担。CircleCI 同样是优秀的 CI/CD 平台，Free plan 的 30,000 credits/mo, that’s up to 6,000 build mins 完全可以支撑起本项目的所有需求，另外 CircleCI 的不同 Project 间的 contexts 设计思想相较于一般的 CI/CD 有很大程度上的创新，更多用户使用并且熟悉 CircleCI，对于用户以及平台来说都是双方受益的。
 
-2. 为什么不采用 Cloudflare Worker 等 Serverless 函数计算？
+3. 为什么不采用 Cloudflare Worker 等 Serverless 函数计算？
    
    已经尝试过 Cloudflare Worker，本地 wrangler dev 有效，但是 deploy Cloudflare Worker 之后，由于 Cloudflare edge 请求会带有明显的 cf 标志，很多平台已经限制了 Cloudflare Worker 的请求。
 
-3. 为什么要切换到 Cloudflare Worker 作为 Webhook 触发器，不用 CircleCI 的 Scheduled？
+4. 为什么要切换到 Cloudflare Worker 作为 Webhook 触发器，不用 CircleCI 的 Scheduled？
    根据 [CircleCI 的最新条款](https://circleci.com/docs/version-control-system-integration-overview/#pipeline-triggers-and-integrations)，Scheduled pipelines 将不对 `GitHub App` 下的个人仓库开放，因此需要切换到 [Custom Webhook](https://circleci.com/docs/custom-webhooks/) 的形式，通过 Cloudflare Worker 作为定时触发器，当然你也可以采用[其他方式调用 Webhook](https://circleci.com/docs/triggers-overview/#trigger-a-pipeline-from-a-custom-webhook)，只需要定时调用 Webhook 的接口即可，这里我采用了 Cloudflare Worker 作为定时触发器。
 
 ## 贡献

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   - 自动签到
   - 自动答题
 - **SakuraFrp**
-  - 自动登录并签到（纯 HTTP 协议解决 GeeTest v3 + MiMo AI 识别验证码）
+  - 自动登录并签到
 
 ## 架构及时序图
 
@@ -147,7 +147,7 @@ https://github.com/timerring/CloudCheckin/blob/0b719258ab4f5f746b067798eb2a4185a
 </details>
 
 <details>
-<summary>配置 SakuraFrp 签到（纯 HTTP + AI 识别验证码）</summary>
+<summary>配置 SakuraFrp 签到</summary>
 
 1. 注册 [SakuraFrp](https://www.natfrp.com/) 账号，获取登录用户名和密码
 2. 将用户名和密码添加到仓库密钥中，命名为 `SAKURAFRP_USERNAME` 和 `SAKURAFRP_PASSWORD`


### PR DESCRIPTION
## Summary

- simplify the SakuraFrp feature description
- remove implementation details from the SakuraFrp configuration headings
- keep the Chinese and English README content aligned

## Why

The overview and section titles should describe the feature concisely without exposing implementation details.

## Validation

- `git diff --check`