### PR TITLE
Fix ImportError on CircleCI: add missing h2 dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           name: Install dependencies
           command: |
             python -m pip install --upgrade pip
-            pip install python-dotenv httpx cryptography openai
+            pip install python-dotenv 'httpx[http2]' cryptography openai
       - run:
           name: Run SakuraFrp signin
           command: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ requests
 2captcha-python
 curl_cffi
 python-dotenv
-httpx
+httpx[http2]
 cryptography
 openai


### PR DESCRIPTION
## Problem

CircleCI 运行 sakurafrp 签到时报 ImportError：

```
SakuraFrp check-in failed unexpectedly (ImportError)
```

## Root Cause

`geetest_crack.py` 创建 httpx client 时用了 `http2=True`，这需要 `h2` 包。CircleCI 的 pip install 列表里没有 `h2`，httpx 初始化时 raise ImportError。

本地能跑是因为 `h2` 被其他依赖间接安装，但 CircleCI 的干净环境没有。

## Fix

- `requirements.txt`: `httpx` → `httpx[http2]`
- `.circleci/config.yml`: `pip install ... httpx ...` → `pip install ... 'httpx[http2]' ...`

`httpx[http2]` 会自动安装 `h2` 包。

---

Co-Authored-By: Oz <oz-agent@warp.dev>
