### PR TITLE
fix(ci): pin CircleCI CLI version

### DIFF
--- a/.github/workflows/deploy-circleci.yml
+++ b/.github/workflows/deploy-circleci.yml
@@ -14,7 +14,8 @@ jobs:
     steps:
       - name: Install CircleCI CLI
         run: |
-          curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
+          curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo env VERSION=0.1.38646 bash
+          circleci version
 
       - name: Setup CircleCI CLI
         run: |


### PR DESCRIPTION
## Summary

- Pin CircleCI CLI to `0.1.38646` in the context setup workflow.
- Print the installed CLI version in Actions logs for easier diagnosis.

## Why

CircleCI CLI `v1.x` removed the `--org-id` flag used by the existing workflow. Because the installer previously resolved the latest release, context creation started failing after the upstream major-version rollout.

Closes #25

## Changed files

```text
.github/
└── workflows/
    └── deploy-circleci.yml
```

## Verification

- YAML syntax parse: passed
- `git diff --check`: passed
- Installed CircleCI CLI `0.1.38646` with the current official installer: passed
- Confirmed `circleci context create --help` supports `--org-id`: passed

## Impact and risk

- Restores compatibility without changing the existing CircleCI context or secret commands.
- Future CLI features and fixes will not be picked up automatically until the pinned version is intentionally updated.
- Rollback is a one-line removal of the `VERSION` environment assignment.