### PR TITLE
fix(ci): report early check-in job failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,38 @@
 version: 2.1
 
+commands:
+  notify-job-failure:
+    parameters:
+      source:
+        type: string
+    steps:
+      - run:
+          name: Notify Telegram about << parameters.source >> failure
+          when: on_fail
+          command: |
+            marker="/tmp/cloudcheckin-telegram-notified"
+            if [ -f "$marker" ]; then
+              echo "A platform notification was already sent; skipping fallback"
+              exit 0
+            fi
+
+            if [ -z "$TELEGRAM_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+              echo "Telegram configuration is incomplete; cannot send failure fallback"
+              exit 0
+            fi
+
+            timestamp=$(TZ=Asia/Shanghai date '+%Y/%m/%d %H:%M:%S')
+            message="${timestamp}
+            << parameters.source >>
+            CircleCI job failed before a platform notification was sent.
+            ${CIRCLE_BUILD_URL}"
+
+            curl --fail --silent --show-error \
+              --request POST \
+              --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+              --data-urlencode "text=${message}" \
+              "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage"
+
 jobs:
   nodeseek:
     docker:
@@ -15,6 +48,8 @@ jobs:
           name: Run Nodeseek signin
           command: |
             python -m nodeseek.nodeseek
+      - notify-job-failure:
+          source: NODESEEK
 
   v2ex:
     docker:
@@ -30,6 +65,8 @@ jobs:
           name: Run V2EX signin
           command: |
             python -m v2ex.v2ex
+      - notify-job-failure:
+          source: V2EX
 
   onepoint3acres:
     docker:
@@ -45,6 +82,8 @@ jobs:
           name: Run 1point3acres signin
           command: |
             python -m onepoint3acres.onepoint3acres
+      - notify-job-failure:
+          source: 1POINT3ACRES
 
   deepflood:
     docker:
@@ -60,6 +99,8 @@ jobs:
           name: Run Deepflood signin
           command: |
             python -m deepflood.deepflood
+      - notify-job-failure:
+          source: DEEPFLOOD
 
   sakurafrp:
     docker:
@@ -75,6 +116,8 @@ jobs:
           name: Run SakuraFrp signin
           command: |
             python -m sakurafrp.sakurafrp
+      - notify-job-failure:
+          source: SAKURAFRP
 
 workflows:
   # Allow manual triggers

--- a/telegram/notify.py
+++ b/telegram/notify.py
@@ -15,6 +15,7 @@ TELEGRAM_TOKEN = os.environ.get('TELEGRAM_TOKEN', '').strip()
 TELEGRAM_CHAT_ID = os.environ.get('TELEGRAM_CHAT_ID', '').strip()
 
 BEIJING_TIMEZONE = timezone(timedelta(hours=8))
+NOTIFICATION_SENT_MARKER = "/tmp/cloudcheckin-telegram-notified"
 
 
 def format_source_notification(source, messages, now=None):
@@ -75,6 +76,14 @@ def send_tg_notification(message):
         # handle response
         if response.status == 200 and result.get('ok'):
             print("Notification sent successfully", flush=True)
+            try:
+                with open(NOTIFICATION_SENT_MARKER, "a", encoding="utf-8"):
+                    pass
+            except OSError as marker_error:
+                print(
+                    f"Could not record notification delivery: {marker_error}",
+                    flush=True,
+                )
         else:
             print(f"Notification sent failed: {response.status} - {data}", flush=True)
             raise Exception(f"Notification sent failed: {response.status} - {data}")

--- a/tests/test_telegram_notify.py
+++ b/tests/test_telegram_notify.py
@@ -1,7 +1,9 @@
 import unittest
 from datetime import datetime, timedelta, timezone
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
 
-from telegram.notify import format_source_notification
+from telegram.notify import format_source_notification, send_tg_notification
 
 
 class FormatSourceNotificationTest(unittest.TestCase):
@@ -29,6 +31,24 @@ class FormatSourceNotificationTest(unittest.TestCase):
             "2026/07/22 10:01:09\nDEEPFLOOD\n"
             "Account 1: successful\nAccount 2: failed",
         )
+
+
+class SendTelegramNotificationTest(unittest.TestCase):
+    @patch("telegram.notify.http.client.HTTPSConnection")
+    def test_records_successful_delivery_for_ci_fallback(self, connection):
+        response = Mock(status=200)
+        response.read.return_value = b'{"ok": true}'
+        connection.return_value.getresponse.return_value = response
+
+        with TemporaryDirectory() as temp_dir:
+            marker = f"{temp_dir}/notification-sent"
+            with patch("telegram.notify.TELEGRAM_TOKEN", "token"), patch(
+                "telegram.notify.TELEGRAM_CHAT_ID", "chat"
+            ), patch("telegram.notify.NOTIFICATION_SENT_MARKER", marker):
+                send_tg_notification("test")
+
+            with open(marker, encoding="utf-8") as marker_file:
+                self.assertEqual(marker_file.read(), "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Send a Telegram fallback when a CircleCI check-in job fails before its platform script can report a result.
- Suppress the fallback when the platform script already delivered a detailed notification.
- Apply the fallback consistently to all five check-in jobs.

## Why

Platform scripts report handled success and failure results, but failures during dependency installation, module import, or process startup happen before that notification code runs. Those jobs could fail in CircleCI without appearing in Telegram.

## Implementation

A reusable CircleCI `on_fail` command sends a platform-labelled fallback with a link to the failed build. Successful Telegram deliveries create a job-local marker so a script-reported failure does not produce a duplicate generic alert.

## Changed files

```text
.circleci/
└── config.yml
telegram/
└── notify.py
tests/
└── test_telegram_notify.py
```

## Verification

- `python -m unittest discover -s tests -v`: passed, 8 tests
- `circleci config validate .circleci/config.yml`: passed
- Ruby YAML parse of `.circleci/config.yml`: passed
- ShellCheck of the expanded fallback shell command: passed
- `git diff --check`: passed

## Impact and risk

- Uses the existing Telegram token and chat ID; no new secrets or migration are required.
- Manually cancelled jobs and jobs terminated by a CircleCI timeout cannot execute `on_fail`, so those cases remain outside this fallback.
- Rollback consists of removing the reusable fallback command, its job hooks, and the delivery marker.