### PR TITLE
fix(notifications): deliver concise failure alerts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ commands:
               exit 0
             fi
 
-            if [ -z "$TELEGRAM_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+            telegram_token=$(printf '%s' "$TELEGRAM_TOKEN" | tr -d '\r\n')
+            telegram_chat_id=$(printf '%s' "$TELEGRAM_CHAT_ID" | tr -d '\r\n')
+            if [ -z "$telegram_token" ] || [ -z "$telegram_chat_id" ]; then
               echo "Telegram configuration is incomplete; cannot send failure fallback"
               exit 0
             fi
@@ -29,9 +31,9 @@ commands:
 
             curl --fail --silent --show-error \
               --request POST \
-              --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+              --data-urlencode "chat_id=${telegram_chat_id}" \
               --data-urlencode "text=${message}" \
-              "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage"
+              "https://api.telegram.org/bot${telegram_token}/sendMessage"
 
 jobs:
   nodeseek:

--- a/deepflood/deepflood.py
+++ b/deepflood/deepflood.py
@@ -3,7 +3,7 @@ from curl_cffi import requests
 import random
 import time
 from dotenv import load_dotenv
-from telegram.notify import send_source_notification
+from telegram.notify import send_source_notification, summarize_http_failure
 
 load_dotenv()
 
@@ -48,7 +48,8 @@ def main():
             if response.status_code == 200:
                 result = f"Account {account}: check-in successful"
             else:
-                result = f"Account {account}: check-in failed — {response.text}"
+                failure = summarize_http_failure(response.status_code, response.text)
+                result = f"Account {account}: check-in failed — {failure}"
                 failed = True
         except Exception as exc:
             result = f"Account {account}: check-in error — {exc}"

--- a/nodeseek/nodeseek.py
+++ b/nodeseek/nodeseek.py
@@ -3,7 +3,7 @@ from curl_cffi import requests
 import random
 import time
 from dotenv import load_dotenv
-from telegram.notify import send_source_notification
+from telegram.notify import send_source_notification, summarize_http_failure
 
 load_dotenv()
 
@@ -48,7 +48,8 @@ def main():
             if response.status_code == 200:
                 result = f"Account {account}: check-in successful"
             else:
-                result = f"Account {account}: check-in failed — {response.text}"
+                failure = summarize_http_failure(response.status_code, response.text)
+                result = f"Account {account}: check-in failed — {failure}"
                 failed = True
         except Exception as exc:
             result = f"Account {account}: check-in error — {exc}"

--- a/telegram/notify.py
+++ b/telegram/notify.py
@@ -1,7 +1,9 @@
 import http.client
+import html
 import urllib.parse
 import json
 import os
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
@@ -16,6 +18,29 @@ TELEGRAM_CHAT_ID = os.environ.get('TELEGRAM_CHAT_ID', '').strip()
 
 BEIJING_TIMEZONE = timezone(timedelta(hours=8))
 NOTIFICATION_SENT_MARKER = "/tmp/cloudcheckin-telegram-notified"
+TELEGRAM_MESSAGE_LIMIT = 4000
+TRUNCATION_SUFFIX = "\n... [message truncated]"
+HTTP_ERROR_DETAIL_LIMIT = 240
+
+
+def summarize_http_failure(status_code, response_text):
+    """Return a compact, notification-safe summary of an HTTP failure."""
+    text = str(response_text or "").strip()
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", text, re.IGNORECASE | re.DOTALL)
+
+    if title_match:
+        detail = html.unescape(title_match.group(1))
+        detail = re.sub(r"\s+", " ", detail).strip()
+    elif text.startswith("<"):
+        detail = "HTML error response"
+    else:
+        detail = re.sub(r"\s+", " ", text).strip()
+
+    if len(detail) > HTTP_ERROR_DETAIL_LIMIT:
+        detail = detail[:HTTP_ERROR_DETAIL_LIMIT - 3].rstrip() + "..."
+
+    summary = f"HTTP {status_code}"
+    return f"{summary}: {detail}" if detail else summary
 
 
 def format_source_notification(source, messages, now=None):
@@ -32,7 +57,15 @@ def format_source_notification(source, messages, now=None):
         body = "No result was reported."
 
     timestamp = now or datetime.now(BEIJING_TIMEZONE)
-    return f"{timestamp.strftime('%Y/%m/%d %H:%M:%S')}\n{source.upper()}\n{body}"
+    notification = (
+        f"{timestamp.strftime('%Y/%m/%d %H:%M:%S')}\n{source.upper()}\n{body}"
+    )
+    if len(notification) > TELEGRAM_MESSAGE_LIMIT:
+        notification = (
+            notification[:TELEGRAM_MESSAGE_LIMIT - len(TRUNCATION_SUFFIX)]
+            + TRUNCATION_SUFFIX
+        )
+    return notification
 
 
 def send_source_notification(source, messages):

--- a/tests/test_telegram_notify.py
+++ b/tests/test_telegram_notify.py
@@ -3,7 +3,13 @@ from datetime import datetime, timedelta, timezone
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
 
-from telegram.notify import format_source_notification, send_tg_notification
+from telegram.notify import (
+    TELEGRAM_MESSAGE_LIMIT,
+    TRUNCATION_SUFFIX,
+    format_source_notification,
+    send_tg_notification,
+    summarize_http_failure,
+)
 
 
 class FormatSourceNotificationTest(unittest.TestCase):
@@ -32,6 +38,19 @@ class FormatSourceNotificationTest(unittest.TestCase):
             "Account 1: successful\nAccount 2: failed",
         )
 
+    def test_truncates_oversized_platform_response(self):
+        now = datetime(2026, 8, 10, 10, 1, 9, tzinfo=timezone(timedelta(hours=8)))
+
+        result = format_source_notification(
+            "deepflood",
+            f"Account 1: check-in failed — {'x' * 5000}",
+            now=now,
+        )
+
+        self.assertEqual(len(result), TELEGRAM_MESSAGE_LIMIT)
+        self.assertTrue(result.startswith("2026/08/10 10:01:09\nDEEPFLOOD\n"))
+        self.assertTrue(result.endswith(TRUNCATION_SUFFIX))
+
 
 class SendTelegramNotificationTest(unittest.TestCase):
     @patch("telegram.notify.http.client.HTTPSConnection")
@@ -49,6 +68,26 @@ class SendTelegramNotificationTest(unittest.TestCase):
 
             with open(marker, encoding="utf-8") as marker_file:
                 self.assertEqual(marker_file.read(), "")
+
+
+class SummarizeHttpFailureTest(unittest.TestCase):
+    def test_extracts_cloudflare_error_title(self):
+        response = """
+            <!DOCTYPE html>
+            <html><head><title>deepflood.com | 522: Connection timed out</title></head></html>
+        """
+
+        result = summarize_http_failure(522, response)
+
+        self.assertEqual(
+            result,
+            "HTTP 522: deepflood.com | 522: Connection timed out",
+        )
+
+    def test_keeps_short_plain_text_error(self):
+        result = summarize_http_failure(403, '{"error": "cookie expired"}')
+
+        self.assertEqual(result, 'HTTP 403: {"error": "cookie expired"}')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Send compact HTTP failure summaries instead of entire response bodies.
- Keep Telegram messages within a safe size limit.
- Normalize Telegram credentials before the CircleCI fallback request.

## Why

Failure alerts could be lost in two ways: Cloudflare error pages exceeded Telegram message limits, and trailing line breaks in CircleCI secrets produced an invalid fallback URL.

Follow-up to #27.

## Changed files

```text
.circleci/
└── config.yml
deepflood/
└── deepflood.py
nodeseek/
└── nodeseek.py
telegram/
└── notify.py
tests/
└── test_telegram_notify.py
```

## Verification

- `python -m unittest discover -s tests -v`: 11 tests passed
- CircleCI configuration YAML parse: passed
- ShellCheck for the fallback notification command: passed
- Credential CR/LF normalization check: passed
- `git diff --check`: passed

## Impact and risk

- No configuration migration is required.
- Full HTTP response bodies remain available in CircleCI logs; Telegram receives only the HTTP status and concise error detail.
- The generic CircleCI fallback remains available if the platform notification cannot be delivered.